### PR TITLE
Updates for PepXML support

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,10 @@
+# Data for Examples and Testing
+
+This directory contains the data files that we use to test mokapot functionality
+and provide examples in the documentation.
+
+These are where the files came from:
+
+- `msfragger.pepXML` was downloaded directly from PRIDE project PXD020243. It is
+  the results from an MSFragger search and was originally named
+  `MSB32231WmutBand_01.pepXML`. [FTP](http://ftp.pride.ebi.ac.uk/pride/data/archive/2020/10/PXD020243/MSB32231WmutBand_01.pepXML)[Paper](https://www.nature.com/articles/s41594-020-0512-7)

--- a/mokapot/config.py
+++ b/mokapot/config.py
@@ -46,11 +46,12 @@ def _parser():
     )
 
     parser.add_argument(
-        "pin_files",
+        "psm_files",
         type=str,
         nargs="+",
         help=(
-            "A collection of PSMs in the Percolator tab-" "delimited format."
+            "A collection of PSMs in the Percolator tab-delimited or PepXML "
+            "format."
         ),
     )
 
@@ -59,9 +60,8 @@ def _parser():
         "--dest_dir",
         type=str,
         help=(
-            "The directory in which to write the result "
-            "files. Defaults to the current working "
-            "directory"
+            "The directory in which to write the result files. Defaults to "
+            "the current working directory"
         ),
     )
 
@@ -246,6 +246,19 @@ def _parser():
             "The number of cross-validation folds to use. "
             "PSMs originating from the same mass spectrum "
             "are always in the same fold."
+        ),
+    )
+
+    parser.add_argument(
+        "--open_modification_bin_size",
+        type=float,
+        help=(
+            "This parameter only affect reading PSMs from PepXML files. "
+            "If specified, modification masses are binned according to the "
+            "value. The binned mass difference is appended to the end of the "
+            "peptide and will be used when grouping peptides for peptide-level"
+            " confidence estimation. Using this option for open modification "
+            "search results. We reommend 0.01 as a good starting point."
         ),
     )
 

--- a/mokapot/parsers/pepxml.py
+++ b/mokapot/parsers/pepxml.py
@@ -47,7 +47,7 @@ def read_pepxml(
     open_modification_bin_size : float, optional
         If specificied, modification masses are binned according to the value.
         The binned mass difference is appended to the end of the peptide and
-        will be used to when grouping peptides for peptide-level confidence
+        will be used when grouping peptides for peptide-level confidence
         estimation. Use this option for open modification search results. We
         recommend 0.01 as a good starting point.
     to_df : bool, optional

--- a/mokapot/parsers/pepxml.py
+++ b/mokapot/parsers/pepxml.py
@@ -82,10 +82,10 @@ def read_pepxml(
     if open_modification_bin_size is not None:
         bins = np.arange(
             psms["mass_diff"].min(),
-            psms["mass_diff"].max() + 1,
+            psms["mass_diff"].max() + open_modification_bin_size,
             step=open_modification_bin_size,
         )
-        bin_idx = np.digitize(psms["mass_diff"], bins)
+        bin_idx = np.digitize(psms["mass_diff"], bins) - 1
         mods = (bins[bin_idx] + (open_modification_bin_size / 2.0)).round(4)
         psms["peptide"] = psms["peptide"] + "[" + mods.astype(str) + "]"
 
@@ -221,7 +221,7 @@ def _parse_psm(psm_info, spec_info, decoy_prefix):
     psm = spec_info.copy()
     psm["calc_mass"] = float(psm_info.get("calc_neutral_pep_mass"))
     psm["peptide"] = psm_info.get("peptide")
-    psm["proteins"] = [psm_info.get("protein")]
+    psm["proteins"] = [psm_info.get("protein").split(" ")[0]]
     psm["label"] = not psm["proteins"][0].startswith(decoy_prefix)
 
     # Begin features:
@@ -257,7 +257,7 @@ def _parse_psm(psm_info, spec_info, decoy_prefix):
             psm["peptide"] = mod_pep
 
         elif "alternative_protein" in element.tag:
-            psm["proteins"].append(element.get("protein"))
+            psm["proteins"].append(element.get("protein").split(" ")[0])
             if not psm["label"]:
                 psm["label"] = not psm["proteins"][-1].startswith(decoy_prefix)
 

--- a/tests/system_tests/test_cli.py
+++ b/tests/system_tests/test_cli.py
@@ -4,30 +4,47 @@ These tests verify that the CLI works as expected.
 At least for now, they do not check the correctness of the
 output, just that the expect outputs are created.
 """
-import os
+from pathlib import Path
 import subprocess
-
-FILES = [
-    os.path.join("data", f)
-    for f in os.listdir("data")
-    if f.startswith("scope")
-]
+import pytest
+import pandas as pd
 
 
-def test_basic_cli(tmp_path):
+@pytest.fixture
+def scope_files():
+    """Get the scope-ms files"""
+    return sorted(list(Path("data").glob("scope*")))
+
+
+@pytest.fixture
+def phospho_files():
+    """Get the phospho file and fasta"""
+    pin = Path("data", "phospho_rep1.pin")
+    fasta = Path("data", "human_sp_td.fasta")
+    return pin, fasta
+
+
+@pytest.fixture
+def pepxml_file():
+    """Get the pepxml file"""
+    pepxml = Path("data", "msfragger.pepXML")
+    return pepxml
+
+
+def test_basic_cli(tmp_path, scope_files):
     """Test that basic cli works."""
-    cmd = ["mokapot", FILES[0], "--dest_dir", tmp_path]
+    cmd = ["mokapot", scope_files[0], "--dest_dir", tmp_path]
     subprocess.run(cmd, check=True)
-    assert os.path.isfile(os.path.join(tmp_path, "mokapot.psms.txt"))
-    assert os.path.isfile(os.path.join(tmp_path, "mokapot.peptides.txt"))
+    assert Path(tmp_path, "mokapot.psms.txt").exists()
+    assert Path(tmp_path, "mokapot.peptides.txt").exists()
 
 
-def test_cli_options(tmp_path):
+def test_cli_options(tmp_path, scope_files):
     """Test non-defaults"""
     cmd = [
         "mokapot",
-        FILES[0],
-        FILES[1],
+        scope_files[0],
+        scope_files[1],
         "--dest_dir",
         tmp_path,
         "--file_root",
@@ -36,8 +53,6 @@ def test_cli_options(tmp_path):
         "0.2",
         "--test_fdr",
         "0.1",
-        "--max_iter",
-        "2",
         "--seed",
         "100",
         "--direction",
@@ -46,40 +61,87 @@ def test_cli_options(tmp_path):
         "2",
         "-v",
         "1",
+        "--max_iter",
+        "1",
     ]
 
     subprocess.run(cmd, check=True)
-    file_bases = [os.path.basename(os.path.splitext(f)[0]) for f in FILES[0:2]]
+    file_bases = [f.name.split(".")[0] for f in scope_files[0:2]]
 
-    assert os.path.isfile(
-        os.path.join(tmp_path, f"blah.{file_bases[0]}.mokapot.psms.txt")
-    )
-    assert os.path.isfile(
-        os.path.join(tmp_path, f"blah.{file_bases[0]}.mokapot.peptides.txt")
-    )
-    assert os.path.isfile(
-        os.path.join(tmp_path, f"blah.{file_bases[1]}.mokapot.psms.txt")
-    )
-    assert os.path.isfile(
-        os.path.join(tmp_path, f"blah.{file_bases[1]}.mokapot.peptides.txt")
-    )
+    assert Path(tmp_path, f"blah.{file_bases[0]}.mokapot.psms.txt").exists()
+    assert Path(
+        tmp_path, f"blah.{file_bases[0]}.mokapot.peptides.txt"
+    ).exists()
+    assert Path(tmp_path, f"blah.{file_bases[1]}.mokapot.psms.txt").exists()
+    assert Path(
+        tmp_path, f"blah.{file_bases[1]}.mokapot.peptides.txt"
+    ).exists()
 
 
-def test_cli_aggregate(tmp_path):
+def test_cli_aggregate(tmp_path, scope_files):
     """Test that aggregate results in one result file."""
     cmd = [
         "mokapot",
-        FILES[0],
-        FILES[1],
+        scope_files[0],
+        scope_files[1],
         "--dest_dir",
         tmp_path,
         "--file_root",
         "blah",
         "--aggregate",
+        "--max_iter",
+        "1",
     ]
 
     subprocess.run(cmd, check=True)
-    file_bases = [os.path.basename(os.path.splitext(f)[0]) for f in FILES[0:2]]
+    assert Path(tmp_path, "blah.mokapot.psms.txt").exists()
+    assert Path(tmp_path, "blah.mokapot.peptides.txt").exists()
 
-    assert os.path.isfile(os.path.join(tmp_path, "blah.mokapot.psms.txt"))
-    assert os.path.isfile(os.path.join(tmp_path, "blah.mokapot.peptides.txt"))
+
+def test_cli_fasta(tmp_path, phospho_files):
+    """Test that proteins happen"""
+    cmd = [
+        "mokapot",
+        phospho_files[0],
+        "--dest_dir",
+        tmp_path,
+        "--proteins",
+        phospho_files[1],
+        "--max_iter",
+        "1",
+    ]
+
+    subprocess.run(cmd, check=True)
+    assert Path(tmp_path, "mokapot.psms.txt").exists()
+    assert Path(tmp_path, "mokapot.peptides.txt").exists()
+    assert Path(tmp_path, "mokapot.proteins.txt").exists()
+
+
+def test_cli_pepxml(tmp_path, pepxml_file):
+    """Test that finding the correct parser works"""
+    cmd = [
+        "mokapot",
+        pepxml_file,
+        "--dest_dir",
+        tmp_path,
+        "--max_iter",
+        "1",
+        "--decoy_prefix",
+        "rev_",
+    ]
+
+    subprocess.run(cmd, check=True)
+    unbinned_file = Path(tmp_path, "mokapot.peptides.txt")
+    assert Path(tmp_path, "mokapot.psms.txt").exists()
+    assert unbinned_file.exists()
+
+    cmd += ["--open_modification_bin_size", "0.01", "--file_root", "binned"]
+    subprocess.run(cmd, check=True)
+    binned_file = Path(tmp_path, "binned.mokapot.peptides.txt")
+    assert Path(tmp_path, "binned.mokapot.psms.txt").exists()
+    assert binned_file.exists()
+
+    # If binning was successful, there should be more distinct peptides:
+    unbinned = pd.read_csv(unbinned_file, sep="\t")
+    binned = pd.read_csv(binned_file, sep="\t")
+    assert len(binned) > len(unbinned)

--- a/tests/unit_tests/test_parser_pepxml.py
+++ b/tests/unit_tests/test_parser_pepxml.py
@@ -43,6 +43,29 @@ def test_pepxml2df(small_pepxml):
     np.testing.assert_array_equal(single["charge_2"], np.array([1, 1, 1, 0]))
     np.testing.assert_array_equal(single["charge_3"], np.array([0, 0, 0, 1]))
 
+    multiple = mokapot.read_pepxml(
+        [small_pepxml, small_pepxml], decoy_prefix="rev_", to_df=True
+    )
+
+    assert len(multiple) == 8
+
+
+def test_pepxml_oms_bin_size(small_pepxml):
+    """Test that bins are working"""
+    psms = mokapot.read_pepxml(
+        small_pepxml,
+        decoy_prefix="rev_",
+        to_df=True,
+        open_modification_bin_size=0.5,
+    )
+    mass = (
+        psms["peptide"]
+        .str.replace(r"^.*\[", "", regex=True)
+        .str.replace(r"\]", "", regex=True)
+        .astype(float)
+    )
+    assert ((mass - psms["mass_diff"]) <= 0.25).all()
+
 
 def test_not_pepxml(not_pepxml):
     """Test that parsing fails gracefully"""


### PR DESCRIPTION
The modification appended to the peptide sequence for open modification searches was incorrect, because the bin index was off by one. This PR fixes it and adds a test.