### PR TITLE
Fasta parsing fails with missing entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 - This changelog.
 
 ### Fixed  
+- Parsing a FASTA file previously failed if an entry was not followed by a 
+  sequence. Now, missing sequences are tolerated and a warning is given instead.  
 - When the learned model was worse than the best feature and the lower scores
-  were better for the best feature, assigning confidence would fail.
+  were better for the best feature, assigning confidence would fail.  
 - Easy access to grouped confidence estimates in the Python API were not working
-  due to a typo.
-- Deprecation warnings from Pandas about the `regex` argument.
+  due to a typo.  
+- Deprecation warnings from Pandas about the `regex` argument.  
 
 ### Changed  
 - Refactored and added many new unit and system tests.

--- a/mokapot/proteins.py
+++ b/mokapot/proteins.py
@@ -432,7 +432,8 @@ def _parse_protein(raw_protein):
         logging.warning("No sequence was detected for %s.", prot)
         return prot, ""
 
-    seq = "".join(entry[1])
+    seq = "".join(entry[1:])
+    print(seq)
     return prot, seq
 
 

--- a/mokapot/proteins.py
+++ b/mokapot/proteins.py
@@ -426,9 +426,13 @@ def _parse_protein(raw_protein):
     sequence : str
         The protein sequence.
     """
-    entry = raw_protein.split("\n", 1)
+    entry = raw_protein.splitlines()
     prot = entry[0].split(" ")[0]
-    seq = entry[1].replace("\n", "")
+    if len(entry) == 1:
+        logging.warning("No sequence was detected for %s.", prot)
+        return prot, ""
+
+    seq = "".join(entry[1])
     return prot, seq
 
 

--- a/tests/unit_tests/test_proteins.py
+++ b/tests/unit_tests/test_proteins.py
@@ -1,0 +1,25 @@
+"""Test that we can parse a FASTA file correctly"""
+import pytest
+from mokapot import FastaProteins
+
+
+@pytest.fixture
+def missing_fasta(tmp_path):
+    """Create a fasta file with a missing entry"""
+    out_file = tmp_path / "missing.fasta"
+    with open(out_file, "w+") as fasta_ref:
+        fasta_ref.write(
+            ">sp|test_1|test_1\n"
+            ">sp|test_2|test_2\n"
+            "TKDIPIIFLSAVNIDKRFITKGYNSGGADY"
+        )
+
+    return out_file
+
+
+def test_fasta_with_missing(missing_fasta):
+    """Test that a fasta file can be parsed with missing entries
+
+    See https://github.com/wfondrie/mokapot/issues/13
+    """
+    FastaProteins(missing_fasta)


### PR DESCRIPTION
This PR adds tolerance for when a entry has no sequence. Additionally, a warning is displayed. This fixes Issue #13. 