### PR TITLE
Fixed a bug with shared peptides and protein grouping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Easy access to grouped confidence estimates in the Python API were not working
   due to a typo.  
 - Deprecation warnings from Pandas about the `regex` argument.  
+- Sometimes peptides were removed as shared incorrectly when part of a protein
+  group.  
 
 ### Changed  
 - Refactored and added many new unit and system tests.

--- a/mokapot/proteins.py
+++ b/mokapot/proteins.py
@@ -209,7 +209,7 @@ def read_fasta(
     decoy_prefix="decoy_",
 ):
     """
-    Parse a FASTA file into a dictionary.
+    Parse a FASTA file into two dictionaries.
 
     Parameters
     ----------
@@ -243,7 +243,6 @@ def read_fasta(
     # Read in the fasta files
     LOGGER.info("Parsing FASTA files and digesting proteins...")
     fasta = _parse_fasta_files(fasta_files)
-
     # Build the initial mapping
     proteins = {}
     peptides = defaultdict(set)
@@ -281,14 +280,19 @@ def read_fasta(
     decoy_map = {}
     no_decoys = 0
     has_decoys = False
+    has_targets = False
     for prot_name in proteins:
         if not prot_name.startswith(decoy_prefix):
+            has_targets = True
             decoy = decoy_prefix + prot_name
             decoy_map[prot_name] = decoy
             if decoy in proteins.keys():
                 has_decoys = True
             else:
                 no_decoys += 1
+
+    if not has_targets:
+        raise ValueError("Only decoy proteins were found in the FASTA file.")
 
     if no_decoys and no_decoys < len(decoy_map):
         LOGGER.warning(
@@ -611,7 +615,7 @@ def _group_proteins(proteins, peptides):
         A map of peptides to their protein groups.
     """
     grouped = {}
-    for prot, peps in proteins.items():
+    for prot, peps in sorted(proteins.items(), key=lambda x: -len(x[1])):
         if not grouped:
             grouped[prot] = peps
             continue
@@ -627,13 +631,15 @@ def _group_proteins(proteins, peptides):
         # Create new entries from subsets:
         for match in matches:
             new_prot = ", ".join([match, prot])
-
             # Update grouped proteins:
             grouped[new_prot] = grouped.pop(match)
 
             # Update peptides:
             for pep in grouped[new_prot]:
                 peptides[pep].remove(match)
+                if prot in peptides[pep]:
+                    peptides[pep].remove(prot)
+
                 peptides[pep].add(new_prot)
 
     return grouped, peptides

--- a/tests/unit_tests/test_proteins.py
+++ b/tests/unit_tests/test_proteins.py
@@ -17,9 +17,150 @@ def missing_fasta(tmp_path):
     return out_file
 
 
+@pytest.fixture
+def target_fasta(tmp_path):
+    """A simple target FASTA"""
+    out_file = tmp_path / "target.fasta"
+    with open(out_file, "w+") as fasta_ref:
+        fasta_ref.write(
+            ">wf|target1\n"
+            "MABCDEFGHIJKLMNOPQRSTUVWXYZKAAAAABRAAABKAAB\n"
+            ">wf|target2\n"
+            "MZYXWVUTSRQPONMLKJIHGFEDCBAKAAAAABRABABKAAB\n"
+            ">wf|target3\n"
+            "A" + "".join(["AB"] * 24) + "AK\n"
+            ">wf|target4\n"
+            "MABCDEFGHIJK"
+        )
+
+    return out_file
+
+
+@pytest.fixture
+def decoy_fasta(tmp_path):
+    """A simple decoy FASTA"""
+    out_file = tmp_path / "decoy.fasta"
+    with open(out_file, "w+") as fasta_ref:
+        fasta_ref.write(
+            ">decoy_wf|target1\n"
+            "MAFGHDCBEIJKLPMQNORSUYTVXWZKAAAABARAABAKABA\n"
+            ">decoy_wf|target2\n"
+            "MZYSVUXWTRQMPOLNKJGIFHBEDCAKAAAABARABBAKABA\n"
+            ">wf|target3\n"
+            "A" + "".join(["BA"] * 24) + "AK\n"
+            ">decoy_wf|target4\n"
+            "MAFGHDCBEIJK"
+        )
+
+    return out_file
+
+
 def test_fasta_with_missing(missing_fasta):
     """Test that a fasta file can be parsed with missing entries
 
     See https://github.com/wfondrie/mokapot/issues/13
     """
     FastaProteins(missing_fasta)
+
+
+def test_target_fasta(target_fasta):
+    """Test that a FASTA file with only targets works"""
+    long_pep = "A" + "".join(["AB"] * 24) + "AK"
+    short_pep = "AAABK"
+
+    # First the default parameters
+    prot = FastaProteins(target_fasta)
+    assert prot.decoy_prefix == "decoy_"
+    assert not prot.has_decoys
+
+    # Check the peptide_map
+    # 0 missed cleavages
+    assert "MABCDEFGHIJK" in prot.peptide_map.keys()
+    # 1 missed cleavage
+    assert "MABCDEFGHIJKLMNOPQR" in prot.peptide_map.keys()
+    # 2 missed cleavages
+    assert "MABCDEFGHIJKLMNOPQRSTUVWXYZK" in prot.peptide_map.keys()
+    # too short
+    assert short_pep not in prot.peptide_map.keys()
+    # too long
+    assert long_pep not in prot.peptide_map.keys()
+
+    # Check the protein map:
+    protein_map = {
+        "wf|target1": "decoy_wf|target1",
+        "wf|target2": "decoy_wf|target2",
+        "wf|target4": "decoy_wf|target4",
+    }
+    assert prot.protein_map == protein_map
+
+    # Check shared peptides:
+    assert prot.shared_peptides == {"AAAAABR"}
+
+
+def test_parameters(target_fasta):
+    """Test that changing the parameters actually changes things."""
+    long_pep = "A" + "".join(["AB"] * 24) + "AK"
+    short_pep = "AAABK"
+
+    prot = FastaProteins(
+        target_fasta,
+        missed_cleavages=0,
+        clip_nterm_methionine=True,
+        min_length=3,
+        max_length=60,
+        decoy_prefix="rev_",
+    )
+    assert prot.decoy_prefix == "rev_"
+    assert not prot.has_decoys
+
+    # Check the peptide_map
+    # 0 missed cleavages
+    assert "MABCDEFGHIJK" in prot.peptide_map.keys()
+    assert "ABCDEFGHIJK" in prot.peptide_map.keys()
+    # 1 missed cleavage
+    assert "ABCDEFGHIJKLMNOPQR" not in prot.peptide_map.keys()
+    # 2 missed cleavages
+    assert "ABCDEFGHIJKLMNOPQRSTUVWXYZK" not in prot.peptide_map.keys()
+    # too short
+    assert short_pep in prot.peptide_map.keys()
+    # too long
+    assert long_pep in prot.peptide_map.keys()
+    # grouped protein:
+    assert "wf|target1, wf|target4" in prot.peptide_map.values()
+
+    # Check the protein map:
+    protein_map = {
+        "wf|target1": "rev_wf|target1",
+        "wf|target2": "rev_wf|target2",
+        "wf|target3": "rev_wf|target3",
+        "wf|target4": "rev_wf|target4",
+    }
+    assert prot.protein_map == protein_map
+
+    # Check shared peptides:
+    assert prot.shared_peptides == {"AAAAABR", "AAB"}
+
+
+def test_decoy_fasta(target_fasta, decoy_fasta):
+    """Test decoys can be provided and used."""
+    # Try without targets:
+    with pytest.raises(ValueError) as msg:
+        FastaProteins(decoy_fasta)
+        assert str(msg).startswith("Only decoy proteins were found")
+
+    # Now do with both:
+    prot = FastaProteins([target_fasta, decoy_fasta])
+
+    # Check the peptide_map
+    # A target sequence
+    assert "MABCDEFGHIJK" in prot.peptide_map.keys()
+    # A decoy sequence
+    assert "MZYSVUXWTRQMPOLNK" in prot.peptide_map.keys()
+
+    # Check the protein map:
+    protein_map = {
+        "wf|target1": "decoy_wf|target1",
+        "wf|target2": "decoy_wf|target2",
+        "wf|target4": "decoy_wf|target4",
+    }
+    assert prot.protein_map == protein_map


### PR DESCRIPTION
Sometimes the original protein was not replaced with the protein group in the peptide to protein map. This caused peptides shared within a protein group to sometimes be discarded as shared peptides.

This PR fixes this behavior and adds tests for it and other things related to FASTA parsing.