### PR TITLE
Support the parsing of PIN files with a "DefaultDirection" line.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for mokapot  
 
+## [Unreleased]
+### Fixed
+- Parsing Percolator tab-delimited files with a "DefaultDirection" line.
+- `Label` column is now converted to boolean during PIN file parsing. 
+  Previously, problems occurred if the `Label` column was of dtype `object`.
+
 ## [0.6.0] - 2021-03-03  
 ### Added  
 - Support for parsing PSMs from PepXML input files.

--- a/mokapot/parsers/pin.py
+++ b/mokapot/parsers/pin.py
@@ -94,6 +94,7 @@ def read_pin(pin_files, group_column=None, to_df=False, copy_data=False):
         )
 
     # Convert labels to the correct format.
+    print(pin_df[labels[0]])
     pin_df[labels[0]] = pin_df[labels[0]].astype(int)
     if any(pin_df[labels[0]] == -1):
         pin_df[labels[0]] = ((pin_df[labels[0]] + 1) / 2).astype(bool)
@@ -142,10 +143,12 @@ def read_percolator(perc_file):
         cols = perc.readline().rstrip().split("\t")
         dir_line = perc.readline().rstrip().split("\t")[0]
         if dir_line.lower() != "defaultdirection":
-            perc.seek(1)
+            perc.seek(0)
+            _ = perc.readline()
 
         psms = pd.concat((c for c in _parse_in_chunks(perc, cols)), copy=False)
 
+    print(psms.head())
     return psms
 
 

--- a/mokapot/parsers/pin.py
+++ b/mokapot/parsers/pin.py
@@ -87,14 +87,16 @@ def read_pin(pin_files, group_column=None, to_df=False, copy_data=False):
             raise ValueError(f"More than one '{name}' column found.")
 
     if not all([specid, peptides, proteins, labels, spectra]):
+        print([specid, peptides, proteins, labels, spectra])
         raise ValueError(
             "This PIN format is incompatible with mokapot. Please"
             " verify that the required columns are present."
         )
 
     # Convert labels to the correct format.
+    pin_df[labels[0]] = pin_df[labels[0]].astype(int)
     if any(pin_df[labels[0]] == -1):
-        pin_df[labels[0]] = (pin_df[labels[0]] + 1) / 2
+        pin_df[labels[0]] = ((pin_df[labels[0]] + 1) / 2).astype(bool)
 
     if to_df:
         return pin_df
@@ -138,6 +140,10 @@ def read_percolator(perc_file):
 
     with fopen(perc_file) as perc:
         cols = perc.readline().rstrip().split("\t")
+        dir_line = perc.readline().rstrip().split("\t")[0]
+        if dir_line.lower() != "defaultdirection":
+            perc.seek(1)
+
         psms = pd.concat((c for c in _parse_in_chunks(perc, cols)), copy=False)
 
     return psms

--- a/tests/unit_tests/test_parser_pin.py
+++ b/tests/unit_tests/test_parser_pin.py
@@ -30,3 +30,8 @@ def test_pin_parsing(std_pin):
 
     dat = mokapot.read_pin(std_pin)
     pd.testing.assert_frame_equal(df.loc[:, ("sCore",)], dat.features)
+
+
+def test_pin_wo_dir():
+    """Test a PIN file without a DefaultDirection line"""
+    dat = mokapot.read_pin("data/scope2_FP97AA.pin")

--- a/tests/unit_tests/test_parser_pin.py
+++ b/tests/unit_tests/test_parser_pin.py
@@ -1,0 +1,32 @@
+"""Test that parsing Percolator input files works correctly"""
+import pytest
+import mokapot
+import pandas as pd
+
+
+@pytest.fixture
+def std_pin(tmp_path):
+    """Create a standard pin file"""
+    out_file = tmp_path / "std_pin"
+    with open(str(out_file), "w+") as pin:
+        dat = (
+            "sPeCid\tLaBel\tpepTide\tsCore\tscanNR\tpRoteins\n"
+            "DefaultDirection\t-\t-\t-\t1\t-\t-\n"
+            "a\t1\tABC\t5\t2\tprotein1\tprotein2\n"
+            "b\t-1\tCBA\t10\t3\tdecoy_protein1\tdecoy_protein2"
+        )
+        pin.write(dat)
+
+    return out_file
+
+
+def test_pin_parsing(std_pin):
+    """Test pin parsing"""
+    df = mokapot.read_pin(std_pin, to_df=True)
+    assert df["LaBel"].dtype == "bool"
+    assert len(df) == 2
+    assert len(df[df["LaBel"]]) == 1
+    assert len(df[df["LaBel"]]) == 1
+
+    dat = mokapot.read_pin(std_pin)
+    pd.testing.assert_frame_equal(df.loc[:, ("sCore",)], dat.features)


### PR DESCRIPTION
Previously, PIN parsing would fail if there was a "DefaultDirection" line. While mokapot still does not support this line, it will now ignore it and parse the file as expected.

This PR also fixes #18. 