### PR TITLE
Fixed problem with parsing modifications from pepXML.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog for mokapot  
 
-## [Unreleased]
+## [0.6.1] - 2021-03-11
 ### Fixed
 - Parsing Percolator tab-delimited files with a "DefaultDirection" line.
 - `Label` column is now converted to boolean during PIN file parsing. 
   Previously, problems occurred if the `Label` column was of dtype `object`.
+- Parsing modifications from pepXML files were indexed incorrectly on the
+  peptide string.
 
 ## [0.6.0] - 2021-03-03  
 ### Added  

--- a/mokapot/parsers/pepxml.py
+++ b/mokapot/parsers/pepxml.py
@@ -253,6 +253,7 @@ def _parse_psm(psm_info, spec_info, decoy_prefix):
                 idx = offset + int(mod.get("position"))
                 mass = mod.get("mass")
                 mod_pep = mod_pep[:idx] + "[" + mass + "]" + mod_pep[idx:]
+                offset += 2 + len(mass)
 
             psm["peptide"] = mod_pep
 


### PR DESCRIPTION
Mods were not being parsed into the peptide string correctly. This PR fixes it.