### PR TITLE
Modernize mokapot's build for PEP517

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install setuptools wheel twine build
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build --sdist --wheel .
         twine upload dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for mokapot  
 
+## [0.7.1] - 2021-03-22  
+### Changed  
+- Updated the build to align with
+  [PEP517](https://www.python.org/dev/peps/pep-0517/)
+
 ## [0.7.0] - 2021-03-19  
 ### Added  
 - Support for downstream peptide and protein quantitation with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,46 @@
+[metadata]
+name = mokapot
+author = William E. Fondrie
+author_email = fondriew@gmail.com
+description = Fast and flexible semi-supervised learning for peptide detection
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/wfondrie/mokapot
+project_urls =
+    Documentation = https://mokapot.readthedocs.io
+    Bug Tracker = https://github.com/wfondrie/mokapot/issues
+    Discussion Board = https://github.com/wfondrie/mokapot/discussions
+license = Apache 2.0
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+    Topic :: Scientific/Engineering :: Bio-Informatics
+
+[options]
+packages = find:
+python_requires = >=3.6
+install_requires =
+    numpy>=1.18.1
+    pandas>=1.0.3
+    scikit-learn>=0.22.1
+    numba>=0.48.0
+    triqler>=0.3.0
+    matplotlib>=3.1.3
+    lxml>=4.6.2
+
+[options.extras_require]
+docs =
+    numpydoc>=1.0.0
+    sphinx-argparse>=0.2.5
+    sphinx-rtd-theme>=0.5.0
+    nbsphinx>=0.7.1
+    ipykernel>=5.3.0
+    recommonmark>=0.5.0
+dev =
+    pre-commit>=2.7.1
+    black>=19.10b0
+
+[options.entry_points]
+console_scripts =
+    mokapot = mokapot.mokapot:main

--- a/setup.py
+++ b/setup.py
@@ -3,48 +3,4 @@ Setup the mokapot package.
 """
 import setuptools
 
-with open("README.md", "r") as readme:
-    LONG_DESC = readme.read()
-
-DESC = "Semi-supervised learning for peptide detection by pretrained models"
-
-CATAGORIES = [
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
-    "Operating System :: OS Independent",
-    "Topic :: Scientific/Engineering :: Bio-Informatics",
-]
-
-setuptools.setup(
-    name="mokapot",
-    author="William E. Fondrie",
-    author_email="fondriew@gmail.com",
-    description=DESC,
-    long_description=LONG_DESC,
-    long_description_content_type="text/markdown",
-    url="https://github.com/wfondrie/mokapot",
-    packages=setuptools.find_packages(),
-    license="Apache 2.0",
-    entry_points={"console_scripts": ["mokapot = mokapot.mokapot:main"]},
-    classifiers=CATAGORIES,
-    install_requires=[
-        "numpy>=1.18.1",
-        "pandas>=1.0.3",
-        "scikit-learn>=0.22.1",
-        "numba>=0.48.0",
-        "triqler>=0.3.0",
-        "matplotlib>=3.1.3",
-        "lxml>=4.6.2",
-    ],
-    extras_require={
-        "docs": [
-            "numpydoc>=1.0.0",
-            "sphinx-argparse>=0.2.5",
-            "sphinx-rtd-theme>=0.5.0",
-            "nbsphinx>=0.7.1",
-            "ipykernel>=5.3.0",
-            "recommonmark>=0.5.0",
-        ],
-        "dev": ["pre-commit>=2.7.1", "black>=19.10b0"],
-    },
-)
+setuptools.setup()


### PR DESCRIPTION
This PR moves mokapot away from using `setup.py` and toward using `setup.cfg` and `pyproject.toml`. This should allow better control of versions using `setuptools-scm`.