### PR TITLE
fixed bug where aggregating ignored --keep_decoys flag

### DIFF
--- a/mokapot/mokapot.py
+++ b/mokapot/mokapot.py
@@ -114,7 +114,11 @@ def main():
     # Determine how to write the results:
     logging.info("Writing results...")
     if config.aggregate or len(config.psm_files) == 1:
-        psms.to_txt(dest_dir=config.dest_dir, file_root=config.file_root)
+        psms.to_txt(
+            dest_dir=config.dest_dir,
+            file_root=config.file_root,
+            decoys=config.keep_decoys,
+        )
     else:
         for dat, prefix in zip(psms, prefixes):
             if config.file_root is not None:

--- a/tests/system_tests/test_cli.py
+++ b/tests/system_tests/test_cli.py
@@ -114,6 +114,14 @@ def test_cli_aggregate(tmp_path, scope_files):
     subprocess.run(cmd, check=True)
     assert Path(tmp_path, "blah.mokapot.psms.txt").exists()
     assert Path(tmp_path, "blah.mokapot.peptides.txt").exists()
+    assert not Path(tmp_path, "blah.mokapot.decoy.psms.txt").exists()
+    assert not Path(tmp_path, "blah.mokapot.decoy.peptides.txt").exists()
+
+    # Test that decoys are also in the output when --keep_decoys is used
+    cmd += ["--keep_decoys"]
+    subprocess.run(cmd, check=True)
+    assert Path(tmp_path, "blah.mokapot.decoy.psms.txt").exists()
+    assert Path(tmp_path, "blah.mokapot.decoy.peptides.txt").exists()
 
 
 def test_cli_fasta(tmp_path, phospho_files):


### PR DESCRIPTION
welp ... I missed this when I submitted https://github.com/wfondrie/mokapot/pull/32

but there was a bug where the --keep_decoys argument was ignored when aggregating the output.
sorry about that ...