### PR TITLE
Improve runtime

### DIFF
--- a/mokapot/config.py
+++ b/mokapot/config.py
@@ -66,6 +66,14 @@ def _parser():
     )
 
     parser.add_argument(
+        "-w",
+        "--max_workers",
+        default=1,
+        type=int,
+        help="The number of processes to use for model training."
+    )
+
+    parser.add_argument(
         "-r",
         "--file_root",
         type=str,

--- a/mokapot/config.py
+++ b/mokapot/config.py
@@ -70,7 +70,7 @@ def _parser():
         "--max_workers",
         default=1,
         type=int,
-        help="The number of processes to use for model training."
+        help="The number of processes to use for model training.",
     )
 
     parser.add_argument(

--- a/mokapot/model.py
+++ b/mokapot/model.py
@@ -432,7 +432,7 @@ class PercolatorModel(Model):
         """Initialize a PercolatorModel"""
         svm_model = LinearSVC(dual=False)
         estimator = GridSearchCV(
-            svm_model, param_grid=PERC_GRID, refit=False, cv=3
+            svm_model, param_grid=PERC_GRID, refit=False, cv=3, n_jobs=-1
         )
 
         super().__init__(

--- a/mokapot/mokapot.py
+++ b/mokapot/mokapot.py
@@ -92,7 +92,11 @@ def main():
 
     # Fit the models:
     psms, models = brew(
-        datasets, model=model, test_fdr=config.test_fdr, folds=config.folds
+        datasets,
+        model=model,
+        test_fdr=config.test_fdr,
+        folds=config.folds,
+        max_workers=config.max_workers,
     )
 
     if config.dest_dir is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,9 +25,9 @@ install_requires =
     pandas>=1.0.3
     scikit-learn>=0.22.1
     numba>=0.48.0
-    triqler>=0.3.0
     matplotlib>=3.1.3
     lxml>=4.6.2
+    triqler @ git+ssh://git@github.com/statisticalbiotechnology/triqler.git
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     numba>=0.48.0
     matplotlib>=3.1.3
     lxml>=4.6.2
-    triqler @ git+ssh://git@github.com/statisticalbiotechnology/triqler.git
+    triqler>=0.6.2
 
 [options.extras_require]
 docs =

--- a/tests/system_tests/test_cli.py
+++ b/tests/system_tests/test_cli.py
@@ -69,6 +69,8 @@ def test_cli_options(tmp_path, scope_files):
         "--keep_decoys",
         "--subset_max_train",
         "50000",
+        "--max_workers",
+        "3",
     ]
 
     subprocess.run(cmd, check=True)


### PR DESCRIPTION
- Expose max workers parameter to cli
- update triqler package with the fix for  [issue #13](https://github.com/statisticalbiotechnology/triqler/issues/13) (calculating PEPs may be extremely slow  for some runs)
- make grid search run with multi-threading


![image](https://user-images.githubusercontent.com/100685091/156387119-c07f41aa-a156-4d35-a0e1-2570a784df67.png)


