### PR TITLE
Enforce `min_length` with `clip_nterm_methionine=True`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: 22.3.0 # Replace by any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
         language_version: python3 # Should be a command that runs python3.6+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for mokapot  
 
+## [Unreleased]
+
+### Fixed
+- Using `clip_nterm_methionine=True` could result in peptides of length
+  `min_length-1`.
+
 ## [0.8.0] - 2022-03-11
 
 Thanks to @sambenfredj, @gessulat, @tkschmidt, and @MatthewThe for 

--- a/mokapot/parsers/fasta.py
+++ b/mokapot/parsers/fasta.py
@@ -259,47 +259,6 @@ def make_decoys(
     return out_file
 
 
-def parse_fasta(
-    fasta_files,
-    enzyme_regex="[KR]",
-    missed_cleavages=0,
-    clip_nterm_methionine=False,
-    min_length=6,
-    max_length=50,
-    semi=False,
-    decoy_prefix="decoy_",
-):
-    """
-    Parse a FASTA file into two dictionaries.
-
-    Parameters
-    ----------
-    fasta_files : str
-        The FASTA file to parse.
-    enzyme_regex : str or compiled regex, optional
-        A regular expression defining the enzyme specificity.
-    missed_cleavages : int, optional
-        The maximum number of allowed missed cleavages.
-    clip_nterm_methionine : bool, optional
-        Remove methionine residues that occur at the protein N-terminus.
-    min_length : int, optional
-        The minimum peptide length.
-    max_length : int, optional
-        The maximum peptide length.
-    semi : bool
-        Allow semi-enzymatic cleavage.
-    decoy_prefix : str
-        The prefix used to indicate decoy sequences.
-
-    Returns
-    -------
-    unique_peptides : dict
-        A dictionary matching unique peptides to proteins.
-    decoy_map : dict
-        A dictionary decoy proteins to their corresponding target proteins.
-    """
-
-
 def digest(
     sequence,
     enzyme_regex="[KR]",
@@ -533,7 +492,8 @@ def _cleave(
             peptides.add(peptide)
 
             if clip_nterm_met and not start_idx and peptide.startswith("M"):
-                peptides.add(peptide[1:])
+                if len(peptide[1:]) >= min_length:
+                    peptides.add(peptide[1:])
 
             # Handle semi:
             if semi:


### PR DESCRIPTION
This PR fixes a small bug where using `clip_nterm_methionine` during digests would allow peptides of `min_length-1`. 