### PR TITLE
Change CLI argument and minor style changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog for mokapot  
 
-## [Unreleased]
+## [0.8.1] - 2022-06-24
+
+### Added
+- Support for previously trained models in the `brew()` function and the CLI 
+  using the `--load_models` argument. Thanks @sambenfredj!
 
 ### Fixed
 - Using `clip_nterm_methionine=True` could result in peptides of length

--- a/mokapot/config.py
+++ b/mokapot/config.py
@@ -253,10 +253,18 @@ def _parser():
     )
 
     parser.add_argument(
-        "--saved_models",
+        "--load_models",
         type=str,
         nargs="+",
-        help=("Use saved models and skip training."),
+        help=(
+            "Load previously saved models and skip model training."
+            "Note that the number of models must match the value of --folds."
+            "If the models are being applied to the same dataset that they "
+            "were trained on originally, the models must be provided in the "
+            "same order as the folds to maintain cross-vaildation fold "
+            "relationships. Failure to do so will result in invalid FDR "
+            "estimates."
+        ),
     )
 
     parser.add_argument(

--- a/mokapot/mokapot.py
+++ b/mokapot/mokapot.py
@@ -82,8 +82,8 @@ def main():
                 dataset.add_proteins(proteins)
 
     # Define a model:
-    if config.saved_models:
-        model = [load_model(model_file) for model_file in config.saved_models]
+    if config.load_models:
+        model = [load_model(model_file) for model_file in config.load_models]
     else:
         model = PercolatorModel(
             train_fdr=config.train_fdr,

--- a/tests/system_tests/test_cli.py
+++ b/tests/system_tests/test_cli.py
@@ -192,7 +192,7 @@ def test_cli_saved_models(tmp_path, phospho_files, models_path):
         tmp_path,
         "--test_fdr",
         "0.01",
-        "--saved_models",
+        "--load_models",
         models_path[0],
         models_path[1],
         models_path[2],

--- a/tests/unit_tests/test_brew.py
+++ b/tests/unit_tests/test_brew.py
@@ -70,7 +70,7 @@ def test_brew_using_few_models_error(psms, svm):
     with pytest.raises(ValueError) as err:
         mokapot.brew(psms, [svm, svm], test_fdr=0.05)
     assert (
-        "The number of trained models (2) must match the number of folds (3)"
+        "The number of trained models (2) must match the number of folds (3)."
         in str(err)
     )
 


### PR DESCRIPTION
Prepare for the 0.8.1 release.

@sambenfredj - please note that I changed the CLI argument from `--saved_models` to `--load_models`. I was looking through the CLI arguments and I had forgotten that there was a `--save_models` argument, which only differs by one letter for the former.