### PR TITLE
Fix missing values caused by logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for mokapot  
 
+## Unreleased
+### Fixed
+- The PepXML parser would sometimes try and log transform features with `0`'s, resulting in missing values.
+
 ## [0.8.1] - 2022-06-24
 
 ### Added

--- a/mokapot/parsers/pepxml.py
+++ b/mokapot/parsers/pepxml.py
@@ -370,6 +370,5 @@ def _log_features(col, features):
                 col[~zero_idx] = np.log10(col[~zero_idx])
                 col[zero_idx] = col[~zero_idx].min() - 1
                 LOGGER.info("  - log-transformed the '%s' feature.", col.name)
-                return np.log10(col)
 
     return col

--- a/mokapot/parsers/pepxml.py
+++ b/mokapot/parsers/pepxml.py
@@ -337,7 +337,7 @@ def _log_features(col, features):
 
     # Detect columns written in scientific notation and log them:
     # This is specifically needed to preserve precision.
-    if col.str.contains("e").any() and (col.astype(float) >= 0).all():
+    if col.str.contains("e").any() and (col.astype(float) > 0).all():
         split = col.str.split("e", expand=True)
         root = split.loc[:, 0]
         root = root.astype(float)


### PR DESCRIPTION
@cia23 saw missing values when trying to parse PepXML results, seemingly caused by log-transforming features with zeros in them. This patch changes the behavior to only log-transform features with values > 0.