### PR TITLE
Make Confidence objects picklable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for mokapot  
 
+## [Unreleased] - 2022-10-25
+### Fixed
+- Confidence objects are now picklable.
+
 ## [0.8.3] - 2022-07-20
 ### Fixed
 - Fixed the reported mokapot score when group FDR is used.

--- a/mokapot/confidence.py
+++ b/mokapot/confidence.py
@@ -183,7 +183,7 @@ class GroupedConfidence:
         return len(self.group_confidence_estimates)
 
 
-class Confidence:
+class Confidence(object):
     """Estimate and store the statistical confidence for a collection of PSMs.
 
     :meta private:
@@ -215,6 +215,9 @@ class Confidence:
         self.decoy_confidence_estimates = {}
 
     def __getattr__(self, attr):
+        if attr.startswith("__"):
+            return super().__getattr__(attr)
+
         try:
             return self.confidence_estimates[attr]
         except KeyError:

--- a/tests/unit_tests/test_confidence.py
+++ b/tests/unit_tests/test_confidence.py
@@ -1,0 +1,68 @@
+"""Test that Confidence classes are working correctly"""
+import pytest
+import pickle
+import numpy as np
+import pandas as pd
+from mokapot import LinearPsmDataset
+
+
+def test_one_group(psm_df_1000):
+    """Test that one group is equivalent to no group."""
+    psm_data, _ = psm_df_1000
+    psm_data["group"] = 0
+
+    psms = LinearPsmDataset(
+        psms=psm_data,
+        target_column="target",
+        spectrum_columns="spectrum",
+        peptide_column="peptide",
+        feature_columns="score",
+        filename_column="filename",
+        scan_column="spectrum",
+        calcmass_column="calcmass",
+        expmass_column="expmass",
+        rt_column="ret_time",
+        charge_column="charge",
+        group_column="group",
+        copy_data=True,
+    )
+
+    np.random.seed(42)
+    grouped = psms.assign_confidence()
+    scores1 = grouped.group_confidence_estimates[0].psms["mokapot score"]
+
+    np.random.seed(42)
+    psms._group_column = None
+    ungrouped = psms.assign_confidence()
+    scores2 = ungrouped.psms["mokapot score"]
+
+    pd.testing.assert_series_equal(scores1, scores2)
+
+
+def test_pickle(psm_df_1000, tmp_path):
+    """Test that pickling works"""
+    psm_data, _ = psm_df_1000
+    psm_data["group"] = 0
+
+    psms = LinearPsmDataset(
+        psms=psm_data,
+        target_column="target",
+        spectrum_columns="spectrum",
+        peptide_column="peptide",
+        feature_columns="score",
+        filename_column="filename",
+        scan_column="spectrum",
+        calcmass_column="calcmass",
+        expmass_column="expmass",
+        rt_column="ret_time",
+        charge_column="charge",
+        copy_data=True,
+    )
+
+    results = psms.assign_confidence()
+    pkl_file = tmp_path / "results.pkl"
+    with pkl_file.open("wb+") as pkl_dat:
+        pickle.dump(results, pkl_dat)
+
+    with pkl_file.open("rb") as pkl_dat:
+        pickle.load(pkl_dat)

--- a/tests/unit_tests/test_confidence.py
+++ b/tests/unit_tests/test_confidence.py
@@ -1,6 +1,7 @@
 """Test that Confidence classes are working correctly"""
-import pytest
 import pickle
+
+import pytest
 import numpy as np
 import pandas as pd
 from mokapot import LinearPsmDataset


### PR DESCRIPTION
I noticed that Confidence objects were not picklable due to their modified `__getattr__()` method. This PR now makes these objects use the parent `__getattr__()` method for all dunder methods (those with a `__` prefix). 