### PR TITLE
✨ Add `seed` keyword to deterministically shuffle splits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,4 +42,5 @@ jobs:
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: 23.1.0 # Replace by any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
         language_version: python3 # Should be a command that runs python3.6+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Breaking changes
 - Mokapot now uses `numpy.random.Generator` instead of the deprecated `numpy.random.RandomState` API. 
-  New `rng` arguments have been added to functions that rely on randomness in lieu of setting a global random seed with `np.random.seed()`. Thanks @sjust-seerbio!
+  New `rng` arguments have been added to functions and classes that rely on randomness in lieu of setting a global random seed with `np.random.seed()`. Thanks @sjust-seerbio!
 
 ## [0.9.1] - 2022-12-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog for mokapot  
 
 ## [Unreleased]
+### Breaking changes
+- Mokapot now uses `numpy.random.Generator` instead of the deprecated `numpy.random.RandomState` API. 
+  New `rng` arguments have been added to functions that rely on randomness in lieu of setting a global random seed with `np.random.seed()`. Thanks @sjust-seerbio!
 
 ## [0.9.1] - 2022-12-14
 ### Changed

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -23,20 +23,6 @@ Alternatively, PSMs that are already represented in a
 Finally, custom machine learning models can be created using the
 :py:class:`mokapot.model.Model` class.
 
-.. note::
-
-   Set your NumPy random seed to ensure reproducibility:
-
-   .. code-block::
-
-      import numpy as np
-      np.random.seed(42)
-
-   In a future release, we will update mokapot to use the `new NumPy random
-   sampling API
-   <https://numpy.org/doc/stable/reference/random/index.html?highlight=random%20sampling%20numpy%20random#module-numpy.random>`_.
-
-
 .. toctree::
    :maxdepth: 1
    :hidden:

--- a/mokapot/brew.py
+++ b/mokapot/brew.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 # Functions -------------------------------------------------------------------
-def brew(psms, model=None, test_fdr=0.01, folds=3, max_workers=1):
+def brew(psms, model=None, test_fdr=0.01, folds=3, max_workers=1, seed=None):
     """
     Re-score one or more collection of PSMs.
 
@@ -59,6 +59,9 @@ def brew(psms, model=None, test_fdr=0.01, folds=3, max_workers=1):
         run time. An integer exceeding the number of folds will have
         no additional effect. Note that logging messages will be garbled
         if more than one worker is enabled.
+    seed: int, optional
+        A seed for the random state used to generate splits, or None to
+        use numpy's default random seed.
 
     Returns
     -------
@@ -90,7 +93,7 @@ def brew(psms, model=None, test_fdr=0.01, folds=3, max_workers=1):
         LOGGER.info("Found %i total PSMs.", sum([len(p.data) for p in psms]))
 
     LOGGER.info("Splitting PSMs into %i folds...", folds)
-    test_idx = [p._split(folds) for p in psms]
+    test_idx = [p._split(folds, seed=seed) for p in psms]
     train_sets = _make_train_sets(psms, test_idx)
     if max_workers != 1:
         # train_sets can't be a generator for joblib :(

--- a/mokapot/brew.py
+++ b/mokapot/brew.py
@@ -118,7 +118,7 @@ def brew(psms, model=None, test_fdr=0.01, folds=3, max_workers=1, seed=None):
         raise err from orig_err
     except TypeError:
         fitted = Parallel(n_jobs=max_workers, require="sharedmem")(
-            delayed(_fit_model)(d, copy.deepcopy(model), f)
+            delayed(_fit_model)(d, copy.deepcopy(model), f, seed=seed)
             for f, d in enumerate(train_sets)
         )
 
@@ -265,7 +265,7 @@ def _predict(dset, test_idx, models, test_fdr):
     return np.concatenate(scores)[rev_idx]
 
 
-def _fit_model(train_set, model, fold):
+def _fit_model(train_set, model, fold, seed):
     """
     Fit the estimator using the training data.
 
@@ -288,7 +288,7 @@ def _fit_model(train_set, model, fold):
     model.fold = fold + 1
     reset = False
     try:
-        model.fit(train_set)
+        model.fit(train_set, seed=seed)
     except RuntimeError as msg:
         if str(msg) != "Model performs worse after training.":
             raise

--- a/mokapot/brew.py
+++ b/mokapot/brew.py
@@ -119,7 +119,7 @@ def brew(psms, model=None, test_fdr=0.01, folds=3, max_workers=1, rng=None):
         raise err from orig_err
     except TypeError:
         fitted = Parallel(n_jobs=max_workers, require="sharedmem")(
-            delayed(_fit_model)(d, copy.deepcopy(model), f, seed=seed)
+            delayed(_fit_model)(d, copy.deepcopy(model), f, rng=rng)
             for f, d in enumerate(train_sets)
         )
 

--- a/mokapot/brew.py
+++ b/mokapot/brew.py
@@ -77,7 +77,7 @@ def brew(psms, model=None, test_fdr=0.01, folds=3, max_workers=1, rng=None):
     """
     rng = np.random.default_rng(rng)
     if model is None:
-        model = PercolatorModel
+        model = PercolatorModel()
 
     try:
         iter(psms)

--- a/mokapot/confidence.py
+++ b/mokapot/confidence.py
@@ -19,6 +19,7 @@ import copy
 import logging
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from triqler import qvality
@@ -61,7 +62,7 @@ class GroupedConfidence:
     group_confidence_estimates: Dict
     """
 
-    def __init__(self, psms, scores, desc=True, eval_fdr=0.01, rng=rng):
+    def __init__(self, psms, scores, desc=True, eval_fdr=0.01, rng=None):
         """Initialize a GroupedConfidence object"""
         group_psms = copy.copy(psms)
         self.group_column = group_psms._group_column
@@ -283,7 +284,7 @@ class Confidence(object):
             self._data,
             psm_columns,
             self._score_column,
-            self.rng,
+            self._rng,
         )
         self._data = self._data.loc[psm_idx, :]
 

--- a/mokapot/confidence.py
+++ b/mokapot/confidence.py
@@ -62,12 +62,11 @@ class GroupedConfidence:
     group_confidence_estimates: Dict
     """
 
-    def __init__(self, psms, scores, desc=True, eval_fdr=0.01, rng=None):
+    def __init__(self, psms, scores, desc=True, eval_fdr=0.01):
         """Initialize a GroupedConfidence object"""
         group_psms = copy.copy(psms)
         self.group_column = group_psms._group_column
         group_psms._group_column = None
-        rng = np.default_rng(rng)
 
         # Do TDC to eliminate multiples PSMs for a spectrum that may occur
         # in different groups.
@@ -95,7 +94,6 @@ class GroupedConfidence:
                 group_scores,
                 desc=desc,
                 eval_fdr=eval_fdr,
-                rng=rng,
             )
             self._group_confidence_estimates[group] = res
 
@@ -206,12 +204,12 @@ class Confidence(object):
         "peptide_pairs": "Peptide Pairs",
     }
 
-    def __init__(self, psms, scores, desc, rng):
+    def __init__(self, psms, scores, desc):
         """Initialize a PsmConfidence object."""
         self._data = psms.metadata
         self._score_column = _new_column("score", self._data)
         self._has_proteins = psms.has_proteins
-        self._rng = np.random.default_rng(rng)
+        self._rng = psms.rng
         if psms.has_proteins:
             self._proteins = psms._proteins
         else:
@@ -340,9 +338,6 @@ class LinearConfidence(Confidence):
     eval_fdr : float
         The FDR threshold at which to report performance. This parameter
         has no affect on the analysis itself, only logging messages.
-    rng : int, np.random.Generator, optional
-        A seed or generator used to break ties, or None to use the
-        default random number generator state.
 
     Attributes
     ----------
@@ -359,9 +354,9 @@ class LinearConfidence(Confidence):
         A dictionary of confidence estimates for the decoys at each level.
     """
 
-    def __init__(self, psms, scores, desc=True, eval_fdr=0.01, rng=None):
+    def __init__(self, psms, scores, desc=True, eval_fdr=0.01):
         """Initialize a a LinearPsmConfidence object"""
-        super().__init__(psms, scores, desc, rng)
+        super().__init__(psms, scores, desc)
         self._target_column = _new_column("target", self._data)
         self._data[self._target_column] = psms.targets
         self._psm_columns = psms._spectrum_columns
@@ -439,6 +434,7 @@ class LinearConfidence(Confidence):
                 self._peptide_column,
                 self._score_column,
                 self._proteins,
+                self._rng,
             )
             levels += ["proteins"]
             level_data += [proteins]

--- a/mokapot/dataset.py
+++ b/mokapot/dataset.py
@@ -316,7 +316,7 @@ class PsmDataset(ABC):
 
         return (scores - target_score) / (target_score - decoy_score)
 
-    def _split(self, folds):
+    def _split(self, folds, seed=None):
         """
         Get the indices for random, even splits of the dataset.
 
@@ -329,6 +329,9 @@ class PsmDataset(ABC):
         ----------
         folds: int
             The number of splits to generate.
+        seed: int, optional
+            A seed for the random state used to generate splits, or None to
+            use numpy's default random seed.
 
         Returns
         -------
@@ -338,7 +341,9 @@ class PsmDataset(ABC):
         """
         cols = list(self._spectrum_columns)
         scans = list(self.data.groupby(cols, sort=False).indices.values())
-        np.random.shuffle(scans)
+
+        rand = np.random.RandomState(seed=seed)
+        rand.shuffle(scans)
         scans = list(scans)
 
         # Split the data evenly

--- a/mokapot/dataset.py
+++ b/mokapot/dataset.py
@@ -345,7 +345,7 @@ class PsmDataset(ABC):
         cols = list(self._spectrum_columns)
         scans = list(self.data.groupby(cols, sort=False).indices.values())
 
-        rand = np.random.default_rng(rng=rng)
+        rand = np.random.default_rng(rng)
         rand.shuffle(scans)
         scans = list(scans)
 

--- a/mokapot/model.py
+++ b/mokapot/model.py
@@ -229,7 +229,7 @@ class Model:
         """Alias for :py:meth:`decision_function`."""
         return self.decision_function(psms)
 
-    def fit(self, psms, seed=None):
+    def fit(self, psms, rng=None):
         """
         Fit the model using the Percolator algorithm.
 
@@ -245,9 +245,9 @@ class Model:
         psms : PsmDataset object
             :doc:`A collection of PSMs <dataset>` from which to train
             the model.
-        seed: int, optional
-            A seed for the random state used to subset/permute the data,
-            or None to use numpy's default random seed.
+        rng : int, np.random.Generator, optional
+            A seed or generator used to generate splits, or None to
+            use the default random number generator state.
 
         Returns
         -------
@@ -266,8 +266,7 @@ class Model:
                 len(psms.data),
             )
 
-        random = np.random.RandomState(seed=seed)
-
+        rng = np.random.default_rng(rng=rng)
         if self.subset_max_train is not None:
             if self.subset_max_train > len(psms):
                 LOGGER.warning(
@@ -283,7 +282,7 @@ class Model:
                     len(psms),
                     self.subset_max_train,
                 )
-                subset_idx = random.choice(
+                subset_idx = rng.choice(
                     len(psms), self.subset_max_train, replace=False
                 )
 

--- a/mokapot/model.py
+++ b/mokapot/model.py
@@ -266,7 +266,7 @@ class Model:
                 len(psms.data),
             )
 
-        rng = np.random.default_rng(rng=rng)
+        rng = np.random.default_rng(rng)
         if self.subset_max_train is not None:
             if self.subset_max_train > len(psms):
                 LOGGER.warning(
@@ -297,7 +297,7 @@ class Model:
         norm_feat = self.scaler.fit_transform(psms.features.values)
 
         # Shuffle order
-        shuffled_idx = random.permutation(np.arange(len(start_labels)))
+        shuffled_idx = rng.permutation(np.arange(len(start_labels)))
         original_idx = np.argsort(shuffled_idx)
         if self.shuffle:
             norm_feat = norm_feat[shuffled_idx, :]

--- a/mokapot/model.py
+++ b/mokapot/model.py
@@ -229,7 +229,7 @@ class Model:
         """Alias for :py:meth:`decision_function`."""
         return self.decision_function(psms)
 
-    def fit(self, psms):
+    def fit(self, psms, seed=None):
         """
         Fit the model using the Percolator algorithm.
 
@@ -245,6 +245,9 @@ class Model:
         psms : PsmDataset object
             :doc:`A collection of PSMs <dataset>` from which to train
             the model.
+        seed: int, optional
+            A seed for the random state used to subset/permute the data,
+            or None to use numpy's default random seed.
 
         Returns
         -------
@@ -263,6 +266,8 @@ class Model:
                 len(psms.data),
             )
 
+        random = np.random.RandomState(seed=seed)
+
         if self.subset_max_train is not None:
             if self.subset_max_train > len(psms):
                 LOGGER.warning(
@@ -278,7 +283,7 @@ class Model:
                     len(psms),
                     self.subset_max_train,
                 )
-                subset_idx = np.random.choice(
+                subset_idx = random.choice(
                     len(psms), self.subset_max_train, replace=False
                 )
 
@@ -293,7 +298,7 @@ class Model:
         norm_feat = self.scaler.fit_transform(psms.features.values)
 
         # Shuffle order
-        shuffled_idx = np.random.permutation(np.arange(len(start_labels)))
+        shuffled_idx = random.permutation(np.arange(len(start_labels)))
         original_idx = np.argsort(shuffled_idx)
         if self.shuffle:
             norm_feat = norm_feat[shuffled_idx, :]

--- a/mokapot/parsers/pin.py
+++ b/mokapot/parsers/pin.py
@@ -13,6 +13,7 @@ from ..dataset import LinearPsmDataset
 
 LOGGER = logging.getLogger(__name__)
 
+
 # Functions -------------------------------------------------------------------
 def read_pin(
     pin_files,

--- a/mokapot/picked_protein.py
+++ b/mokapot/picked_protein.py
@@ -13,7 +13,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def picked_protein(
-    peptides, target_column, peptide_column, score_column, proteins
+    peptides, target_column, peptide_column, score_column, proteins, rng
 ):
     """Perform the picked-protein approach
 
@@ -27,6 +27,8 @@ def picked_protein(
         The column in `peptides` containing the peptide sequence.
     proteins : Proteins object
         A Proteins object.
+    rng : int or numpy.random.Generator
+        The random number generator.
 
     Returns
     -------
@@ -118,7 +120,7 @@ def picked_protein(
         .map(lambda x: proteins.protein_map.get(x, x))
     )
 
-    prot_idx = utils.groupby_max(prots, ["decoy"], score_column)
+    prot_idx = utils.groupby_max(prots, ["decoy"], score_column, rng)
     final_cols = [
         "mokapot protein group",
         "best peptide",

--- a/mokapot/utils.py
+++ b/mokapot/utils.py
@@ -7,11 +7,11 @@ import numpy as np
 import pandas as pd
 
 
-def groupby_max(df, by_cols, max_col):
+def groupby_max(df, by_cols, max_col, rng):
     """Quickly get the indices for the maximum value of col"""
     by_cols = tuplize(by_cols)
     idx = (
-        df.sample(frac=1)
+        df.sample(frac=1, random_state=rng)
         .sort_values(list(by_cols) + [max_col], axis=0)
         .drop_duplicates(list(by_cols), keep="last")
         .index

--- a/tests/unit_tests/test_brew.py
+++ b/tests/unit_tests/test_brew.py
@@ -49,6 +49,38 @@ def test_brew_folds(psms, svm):
     assert len(models) == 4
 
 
+def test_brew_seed(psms, svm):
+    """Test that (not) changing the split selection seed works"""
+    folds = 3
+    seed = 0
+
+    results_a, models_a = mokapot.brew(
+        psms, svm, test_fdr=0.05, folds=folds, seed=seed
+    )
+    assert isinstance(results_a, mokapot.confidence.LinearConfidence)
+    assert len(models_a) == folds
+
+    results_b, models_b = mokapot.brew(
+        psms, svm, test_fdr=0.05, folds=folds, seed=seed
+    )
+    assert isinstance(results_b, mokapot.confidence.LinearConfidence)
+    assert len(models_b) == folds
+
+    assert (
+        results_a.accepted == results_b.accepted
+    ), "Results differed with same seed"
+
+    results_c, models_c = mokapot.brew(
+        psms, svm, test_fdr=0.05, folds=folds, seed=seed + 1
+    )
+    assert isinstance(results_c, mokapot.confidence.LinearConfidence)
+    assert len(models_c) == folds
+
+    assert (
+        results_a.accepted != results_c.accepted
+    ), "Results were identical with different seed!"
+
+
 def test_brew_test_fdr_error(psms, svm):
     """Test that we get a sensible error message"""
     with pytest.raises(RuntimeError) as err:
@@ -66,15 +98,13 @@ def test_brew_multiprocess(psms, svm):
 def test_brew_trained_models(psms, svm):
     """Test that using trained models reproduces same results"""
     # fix a seed to have the same random split for each run
-    np.random.seed(3)
     results_with_training, models_with_training = mokapot.brew(
-        psms, svm, test_fdr=0.05
+        psms, svm, test_fdr=0.05, seed=3
     )
-    np.random.seed(3)
     models = list(models_with_training)
     models.reverse()  # Change the model order
     results_without_training, models_without_training = mokapot.brew(
-        psms, models, test_fdr=0.05
+        psms, models, test_fdr=0.05, seed=3
     )
     assert models_with_training == models_without_training
     assert results_with_training.accepted == results_without_training.accepted

--- a/tests/unit_tests/test_brew.py
+++ b/tests/unit_tests/test_brew.py
@@ -71,7 +71,7 @@ def test_brew_seed(psms, svm):
     ), "Results differed with same seed"
 
     results_c, models_c = mokapot.brew(
-        psms, svm, test_fdr=0.05, folds=folds, rng=seed + 1
+        psms, svm, test_fdr=0.05, folds=folds, rng=seed + 2
     )
     assert isinstance(results_c, mokapot.confidence.LinearConfidence)
     assert len(models_c) == folds
@@ -99,12 +99,12 @@ def test_brew_trained_models(psms, svm):
     """Test that using trained models reproduces same results"""
     # fix a seed to have the same random split for each run
     results_with_training, models_with_training = mokapot.brew(
-        psms, svm, test_fdr=0.05, seed=3
+        psms, svm, test_fdr=0.05, rng=3
     )
     models = list(models_with_training)
     models.reverse()  # Change the model order
     results_without_training, models_without_training = mokapot.brew(
-        psms, models, test_fdr=0.05, seed=3
+        psms, models, test_fdr=0.05, rng=3
     )
     assert models_with_training == models_without_training
     assert results_with_training.accepted == results_without_training.accepted

--- a/tests/unit_tests/test_brew.py
+++ b/tests/unit_tests/test_brew.py
@@ -55,13 +55,13 @@ def test_brew_seed(psms, svm):
     seed = 0
 
     results_a, models_a = mokapot.brew(
-        psms, svm, test_fdr=0.05, folds=folds, seed=seed
+        psms, svm, test_fdr=0.05, folds=folds, rng=seed
     )
     assert isinstance(results_a, mokapot.confidence.LinearConfidence)
     assert len(models_a) == folds
 
     results_b, models_b = mokapot.brew(
-        psms, svm, test_fdr=0.05, folds=folds, seed=seed
+        psms, svm, test_fdr=0.05, folds=folds, rng=seed
     )
     assert isinstance(results_b, mokapot.confidence.LinearConfidence)
     assert len(models_b) == folds
@@ -71,7 +71,7 @@ def test_brew_seed(psms, svm):
     ), "Results differed with same seed"
 
     results_c, models_c = mokapot.brew(
-        psms, svm, test_fdr=0.05, folds=folds, seed=seed + 1
+        psms, svm, test_fdr=0.05, folds=folds, rng=seed + 1
     )
     assert isinstance(results_c, mokapot.confidence.LinearConfidence)
     assert len(models_c) == folds

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -21,21 +21,20 @@ def df():
 
 def test_groupby_max(df):
     """Test that the groupby_max() function works"""
-    np.random.seed(42)
     in_df, val1_max = df
 
     # Verify that the basic idea works:
-    idx = utils.groupby_max(in_df, "group", "val1")
+    idx = utils.groupby_max(in_df, "group", "val1", 42)
     out_df = in_df.loc[idx, :].sort_values("group").reset_index(drop=True)
     pd.testing.assert_frame_equal(val1_max, out_df)
 
-    idx = utils.groupby_max(in_df, ["group"], "val1")
+    idx = utils.groupby_max(in_df, ["group"], "val1", 42)
     out_df = in_df.loc[idx, :].sort_values("group").reset_index(drop=True)
     pd.testing.assert_frame_equal(val1_max, out_df)
 
     # Verify that the shuffling bit works:
-    idx1 = set(utils.groupby_max(in_df, "group", "val2"))
-    idx2 = set(utils.groupby_max(in_df, "group", "val2"))
+    idx1 = set(utils.groupby_max(in_df, "group", "val2", 2))
+    idx2 = set(utils.groupby_max(in_df, "group", "val2", 1))
     assert idx1 != idx2
 
 


### PR DESCRIPTION
In some cases it's desirable to produce deterministic splits. For example, when unit testing code that uses Mokapot internally, or to benchmark specific changes without randomness interfering.

This PR adds a `seed` parameter to the `brew()`, `fit()` and `_split()` functions and tests that they behave as expected.

This approach is preferable to calling `np.random.seed()` before invoking `brew()`, as it ensures that the seed is passed directly to the random state used by `_split()` and `fit()`. However, this change does mean that any code relying on `np.random.seed()` to control the internal random state of Mokapot will not function as before. It should be possible to restore this functionality while preserving the new parameter by altering the handling of the `seed=None` case.