### PR TITLE
Replace logging.[...] with LOGGER.[...]

### DIFF
--- a/mokapot/brew.py
+++ b/mokapot/brew.py
@@ -181,13 +181,13 @@ def brew(psms, model=None, test_fdr=0.01, folds=3, max_workers=1, rng=None):
         descs = [True] * len(psms)
 
     if using_best_feat:
-        logging.warning(
+        LOGGER.warning(
             "Learned model did not improve over the best feature. "
             "Now scoring by the best feature for each collection "
             "of PSMs."
         )
     elif reset:
-        logging.warning(
+        LOGGER.warning(
             "Learned model did not improve upon the pretrained "
             "input model. Now re-scoring each collection of PSMs "
             "using the original model."

--- a/mokapot/model.py
+++ b/mokapot/model.py
@@ -540,7 +540,7 @@ def load_model(model_file):
     # Try a percolator model first:
     try:
         weights = pd.read_csv(model_file, sep="\t", nrows=2).loc[1, :]
-        logging.info("Loading the Percolator model.")
+        LOGGER.info("Loading the Percolator model.")
 
         weight_cols = [c for c in weights.index if c != "m0"]
         model = Model(estimator=LinearSVC(), scaler="as-is")
@@ -553,7 +553,7 @@ def load_model(model_file):
 
     # Then try loading it with pickle:
     except (KeyError, UnicodeDecodeError):
-        logging.info("Loading mokapot model.")
+        LOGGER.info("Loading mokapot model.")
         with open(model_file, "rb") as mod_in:
             model = pickle.load(mod_in)
 


### PR DESCRIPTION
Simply replacing some log calls to the root logger (`logging`) to the module-level logger (`LOGGER`). Not sure if there were specific reasons to keep these log calls on the root logger. If there were, please ignore this PR :)