### PR TITLE
Add workflow for building Windows installer

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,23 +5,58 @@ on:
     types: [created]
 
 jobs:
-  deploy:
+  deploy-pypi:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine build
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python -m build --sdist --wheel .
-        twine upload dist/*
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine build
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python -m build --sdist --wheel .
+          twine upload dist/*
+
+  windows-installer:
+    runs-on: windows-latest
+    needs: deploy-pypi
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install package and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install . pyinstaller
+      - name: Install Inno Setup
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install innosetup -y --allow-unofficial --force
+      - name: Run pyinstaller
+        run: pyinstaller ./pyinstaller.spec --clean --noconfirm
+      - name: Test built exe
+        run: dist/mokapot/mokapot.exe --help
+      - name: Run Inno Setup
+        run: ISCC.exe ./innosetup.iss /DAppVersion=${{  github.ref_name }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist/*.exe
+      - name: Upload installer to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          file_glob: true
+          file: dist/*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/innosetup.iss
+++ b/innosetup.iss
@@ -1,0 +1,46 @@
+#include "innosetup_environment.iss"
+
+#define AppName "Mokapot"
+#define AppPublisher "wfondrie"
+#define AppURL "https://github.com/wfondrie/mokapot/"
+#define AppExeName "mokapot.exe"
+
+[Setup]
+AppId={{35695E10-2C07-47AF-97F6-DF0CF332A47C}
+AppName={#AppName}
+AppVersion={#AppVersion}
+;AppVerName={#AppName} {#AppVersion}
+AppPublisher={#AppPublisher}
+AppPublisherURL={#AppURL}
+AppSupportURL={#AppURL}
+AppUpdatesURL={#AppURL}
+LicenseFile=.\LICENSE
+DefaultDirName={autopf}\{#AppName}
+DisableProgramGroupPage=yes
+; Remove the following line to run in administrative install mode (install for all users.)
+PrivilegesRequired=lowest
+;PrivilegesRequiredOverridesAllowed=dialog
+OutputDir=dist
+OutputBaseFilename={#AppName}-{#AppVersion}-Windows64bit
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+ChangesEnvironment=true
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Files]
+Source: "dist\mokapot\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#AppExeName}"
+
+[Run]
+Filename: "{app}\{#AppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(AppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+
+[Registry]
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"
+
+
+

--- a/innosetup.iss
+++ b/innosetup.iss
@@ -1,5 +1,3 @@
-#include "innosetup_environment.iss"
-
 #define AppName "Mokapot"
 #define AppPublisher "wfondrie"
 #define AppURL "https://github.com/wfondrie/mokapot/"
@@ -9,7 +7,6 @@
 AppId={{35695E10-2C07-47AF-97F6-DF0CF332A47C}
 AppName={#AppName}
 AppVersion={#AppVersion}
-;AppVerName={#AppName} {#AppVersion}
 AppPublisher={#AppPublisher}
 AppPublisherURL={#AppURL}
 AppSupportURL={#AppURL}
@@ -17,9 +14,7 @@ AppUpdatesURL={#AppURL}
 LicenseFile=.\LICENSE
 DefaultDirName={autopf}\{#AppName}
 DisableProgramGroupPage=yes
-; Remove the following line to run in administrative install mode (install for all users.)
 PrivilegesRequired=lowest
-;PrivilegesRequiredOverridesAllowed=dialog
 OutputDir=dist
 OutputBaseFilename={#AppName}-{#AppVersion}-Windows64bit
 Compression=lzma
@@ -41,6 +36,3 @@ Filename: "{app}\{#AppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(
 
 [Registry]
 Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"
-
-
-

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -1,0 +1,101 @@
+import importlib.metadata
+import os
+import re
+
+from PyInstaller.building.build_main import COLLECT, EXE, PYZ, Analysis
+from PyInstaller.utils.hooks import collect_all
+
+from mokapot import __version__
+
+# Package info
+exe_name = "mokapot"
+script_name = "mokapot/mokapot.py"
+location = os.getcwd()
+project = "mokapot"
+bundle_name = "mokapot"
+bundle_identifier = f"{bundle_name}.{__version__}"
+block_cipher = None
+
+# Requirements config
+skip_requirements_regex = r"^(?:.*\..*)"
+
+# Collect hidden imports and data for all requirements
+requirements = importlib.metadata.requires(project)
+requirements = {
+    re.match(r"^[\w\-]+", req)[0]  # Remove version specifiers
+    for req in requirements
+    if "; extra ==" not in req  # Exclude optional dependencies
+}
+requirements.update([project])
+hidden_imports = set()
+datas = []
+binaries = []
+checked = set()
+while requirements:
+    requirement = requirements.pop()
+    if re.match(skip_requirements_regex, requirement):
+        continue
+    checked.add(requirement)
+    module_version = importlib.metadata.version(re.match(r"^[\w\-]+", requirement)[0])
+    try:
+        datas_, binaries_, hidden_imports_ = collect_all(requirement, include_py_files=True)
+    except ImportError:
+        continue
+    datas += datas_
+    hidden_imports_ = set(hidden_imports_)
+    if "" in hidden_imports_:
+        hidden_imports_.remove("")
+    if None in hidden_imports_:
+        hidden_imports_.remove(None)
+    requirements |= hidden_imports_ - checked
+    hidden_imports |= hidden_imports_
+
+hidden_imports = sorted([h for h in hidden_imports if "tests" not in h.split(".")])
+hidden_imports = [h for h in hidden_imports if "__pycache__" not in h]
+datas = [
+    d
+    for d in datas
+    if ("__pycache__" not in d[0]) and (d[1] not in [".", "build", "dist", "Output"])
+]
+
+# Build package
+a = Analysis(
+    [script_name],
+    pathex=[location],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hidden_imports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name=exe_name,
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    # Windows specific
+    console=True,
+    windowed=False,
+    disable_windowed_traceback=False,
+)
+
+coll = COLLECT(
+    exe, a.binaries, a.zipfiles, a.datas, strip=False, upx=True, upx_exclude=[], name=exe_name
+)


### PR DESCRIPTION
This PR partially addresses #101:

- `pyinstaller.spec` instructs PyInstaller to freeze mokapot with all its dependencies (including Python) with an executable. 
- `innosetup.iss` instructs InnoSetup to bundle everything in a Windows Installer exe.
- I extended `.github/workflows/publish.yml` to go through the above two steps and upload the exe as an asset to the release.

What is still needed to fully implement #101:
- [ ] Run PyInstaller on macOS
- [ ] Find a way to bundle the frozen package into a macOS installer
- [ ] Run PyInstaller on Linux (not sure which distros are needed?)
- [ ] Find a way to bundle the frozen package into a Linux installer for each distro

I don't have any experience with these open issues, so I leave them open for someone else to tackle.