### PR TITLE
set a default extension for TabularDataReader

### DIFF
--- a/mokapot/tabular_data/base.py
+++ b/mokapot/tabular_data/base.py
@@ -62,7 +62,8 @@ class TabularDataReader(ABC):
         return True
 
     def get_default_extension(self) -> str:
-        raise NotImplementedError
+        # raise NotImplementedError
+        return ".tsv"
 
     @staticmethod
     def from_path(


### PR DESCRIPTION
### Purpose


when assigning confidence, a NotImplementedError is raised. I

```mokapot/mokapot/confidence.py", line 1150, in create_sorted_file_reader
    outfile_ext = dataset.get_default_extension()

    mokapot/mokapot/confidence.py", line 1150, in create_sorted_file_reader
    outfile_ext = dataset.get_default_extension()

    mokapot/mokapot/tabular_data/base.py", line 65, in get_default_extension
    raise NotImplementedError
NotImplementedError

```

I looked at importing and using CsvFileReader inside confidence.py, but became confused with the inheritance scheme of the various Dataset objects and where they were being created. Simply providing a reasonable return value solved the issue, but there may be a more preferred way to solve this.  