### PR TITLE
Improve training and diagnostic logging

### DIFF
--- a/mokapot/brew.py
+++ b/mokapot/brew.py
@@ -293,10 +293,16 @@ def brew(
         descs = [True] * len(datasets)
 
     if using_best_feat:
+        feat_name = best_feats[best_feat_idx][0]
+        name_str = f" '{feat_name}'" if isinstance(feat_name, str) else ""
         LOGGER.warning(
-            "Learned model did not improve over the best feature. "
-            "Now scoring by the best feature for each collection "
-            "of PSMs."
+            "Learned model did not improve over the best feature%s "
+            "(%i PSMs at q<=%g vs %i for the model). "
+            "Now scoring by the best feature for each collection of PSMs.",
+            name_str,
+            feat_total,
+            test_fdr,
+            pred_total,
         )
     elif reset:
         LOGGER.warning(

--- a/mokapot/confidence.py
+++ b/mokapot/confidence.py
@@ -509,7 +509,12 @@ def assign_confidence(
         if any(dataset.scores is None for dataset in datasets):
             LOGGER.info("No scores found, attempting to find best feature.")
             feature = datasets[0].find_best_feature(eval_fdr).feature
-            LOGGER.info("Best feature found: %s", feature)
+            LOGGER.info(
+                "Best feature: '%s' (%i PSMs at q<=%g).",
+                feature.name,
+                feature.positives,
+                eval_fdr,
+            )
             scores_use = [
                 dataset.read_data(columns=[feature.name])[
                     feature.name

--- a/mokapot/model.py
+++ b/mokapot/model.py
@@ -338,7 +338,7 @@ class Model:
             target = target[shuffled_idx]
             num_passed.append((target == 1).sum())
 
-            LOGGER.debug(
+            LOGGER.info(
                 "\t- Iteration %i: %i training PSMs passed.", i, num_passed[i]
             )
 
@@ -362,9 +362,9 @@ class Model:
         self.estimator = model
         weights = _get_weights(self.estimator, self.features)
         if weights is not None:
-            LOGGER.debug("Normalized feature weights in the learned model:")
+            LOGGER.info("Normalized feature weights in the learned model:")
             for line in weights:
-                LOGGER.debug("    %s", line)
+                LOGGER.info("    %s", line)
 
         self.is_trained = True
         LOGGER.info("Done training.")

--- a/mokapot/parsers/pin.py
+++ b/mokapot/parsers/pin.py
@@ -236,15 +236,27 @@ def read_percolator(
         feature for feature in features if feature not in features_to_drop
     ]
 
-    LOGGER.info("Using %i features:", len(_feature_columns))
+    LOGGER.info("Using %i features.", len(_feature_columns))
     for i, feat in enumerate(_feature_columns):
-        LOGGER.info("  (%i)\t%s", i + 0, feat)
+        LOGGER.debug("  (%i)\t%s", i, feat)
 
     prelim_columns.update(
         feature_columns=_feature_columns,
     )
     column_groups = prelim_columns
-    LOGGER.info(f"Infered column grouping: {pformat(column_groups)}")
+
+    # Log a concise summary of the inferred column roles at INFO; the full
+    # ColumnGroups dump is only emitted at DEBUG.
+    opt = column_groups.optional_columns
+    LOGGER.info("Inferred column roles:")
+    LOGGER.info("  - target:   %s", column_groups.target_column)
+    LOGGER.info("  - peptide:  %s", column_groups.peptide_column)
+    LOGGER.info("  - spectrum: %s", ", ".join(column_groups.spectrum_columns))
+    if opt.id is not None:
+        LOGGER.info("  - id:       %s", opt.id)
+    if opt.protein is not None:
+        LOGGER.info("  - protein:  %s", opt.protein)
+    LOGGER.debug("Full inferred column grouping:\n%s", pformat(column_groups))
 
     return OnDiskPsmDataset(
         perc_file,


### PR DESCRIPTION
## Summary

Follow-up to #142. Makes the linear-model diagnostics visible at the default `INFO` level and tidies the column-inference output, so it's clear how a run was scored (and why mokapot fell back to a single feature when it does).

## Changes
- **`model.py`**: log the per-iteration training-loop progress and the learned linear-model **feature weights** at `INFO` (were `DEBUG`, so hidden by default).
- **`brew.py`**: when the learned model doesn't beat the best single feature and mokapot falls back to it, report **both PSM counts** (best feature vs model) so the fallback reason is explicit.
- **`confidence.py`**: when `assign_confidence` falls back to the best feature, log its name and the number of PSMs it accepts at the eval FDR.
- **`parsers/pin.py`**: replace the raw `ColumnGroups` `pformat` dump with a concise summary of the inferred column roles at `INFO` (full dump → `DEBUG`; per-feature list → `DEBUG`); fix the "Infered" typo.

## Verification
`ruff check` clean; full unit suite passes (161). Verified the new logs render cleanly (column roles, per-feature weights, best-feature PSM counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)